### PR TITLE
ci: pin ubuntu-latest to ubuntu-24.04

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   js-linter:
     name: Javascript linter (standard)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - name: Init yarn
@@ -21,7 +21,7 @@ jobs:
           files: html/*
   css-linter:
     name: CSS linter (stylelint)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - name: Init yarn
@@ -30,7 +30,7 @@ jobs:
         run: yarn stylelint html/*.css
   html-linter:
     name: HTML linter (html5validator) 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
       - uses: Cyb3r-Jak3/html5validator-action@v8.0.0


### PR DESCRIPTION
## Summary
- Pin `ubuntu-latest` to `ubuntu-24.04` in all GitHub Actions workflows

Prevents unexpected behavior changes when GitHub updates the `ubuntu-latest` label.
Tracked by [CNFCERT-1419](https://redhat.atlassian.net/browse/CNFCERT-1419).